### PR TITLE
Add Airsonic apps

### DIFF
--- a/apps.md
+++ b/apps.md
@@ -13,7 +13,9 @@ You can find a detailed list of applications available for Subsonic on the [Subs
 | Name   | Available | Free |  Notes  |
 |:----------:|:-------:|:---------:|:-------:|:------:|
 | Subsonic  | [Google Play](https://play.google.com/store/apps/details?id=net.sourceforge.subsonic.androidapp) | ✔ |The official Subsonic app made by Sindre Mehus.
+| DSub  | [F-Droid Repository](https://f-droid.org/packages/github.daneren2005.dsub/) | ✔ | A Subsonic client fork.   
 | DSub  | [Google Play](https://play.google.com/store/apps/details?id=github.daneren2005.dsub) | ✕  | Not free but very good. Made by Scott Jackson.
+| Audinaut | [F-Droid Repository](https://f-droid.org/app/net.nullsum.audinaut) | ✔ | Made by Andrew Rabert.
 | XenoAmp  | [Google Play](https://play.google.com/store/apps/details?id=pl.qus.xenoamp&hl=en) | ✔ | Supports many different services (Soundcloud, Subsonic, SMB...)
 | Substreamer  | [Google Play](https://play.google.com/store/apps/details?id=com.ghenry22.substream2), [App Store](https://itunes.apple.com/us/app/substreamer/id1012991665?ls=1&mt=8) | ✔ | -
 | Subsonic Music Streamer | [Windows Store](https://www.microsoft.com/de-at/store/p/subsonic-music-streamer/9nblggh0dfs4?rtc=1) | ✕  | Made by Anton Van Zuylen.
@@ -30,8 +32,10 @@ You can find a detailed list of applications available for Subsonic on the [Subs
 
 | Name   | Platform | Free |  Notes  |
 |:----------:|:-------:|:---------:|:-------:|:------:|
-| [Submariner](http://www.read-write.fr/subapp/index.php)  | Mac | ✔  | A native mac music application.
+| [Clementine](https://www.clementine-player.org/) | Windows, Mac OS, Linux | ✔ | A multiplatform music player. Provides support for many different services beside Airsonic (Souncloud, Spotify...)
+| [Submariner](http://www.read-write.fr/subapp/index.php)  | Mac OS | ✔  | A native mac music application.
 | [Subsonic Plugin](http://musicbee.wikia.com/wiki/Subsonic_Client) for [MusicBee](https://getmusicbee.com/)  | Windows | ✔  | Provides support for many different services (SoundCloud, web radio...)
+| [Jamstash](http://jamstash.com/#/settings) | Web, Google Chrome ([Web Store](https://chrome.google.com/webstore/detail/jamstash/jccdpflnecheidefpofmlblgebobbloc)) | ✔ | A HTML 5 music player.
 | [Perisonic](https://chrome.google.com/webstore/detail/perisonic/bkdipjpecphmbijlckkkmabnabhbpjbn) | Google Chrome | ✔  | Plays your music in random order.
 | [PolySonic](https://chrome.google.com/webstore/detail/polysonic/dmijgonnbeadbncajpphnlidgjkgmblf) | Google Chrome | ✔  | Simple subsonic player based on Polymer.
 

--- a/apps.md
+++ b/apps.md
@@ -1,6 +1,37 @@
 ---
 layout: docs
-title: Airsonic applications
+title: Airsonic Applications
 permalink: /docs/apps/
 ---
-**Work in progress**
+
+Airsonic and [Subsonic](http://www.subsonic.org) provide the same API. This means that all Subsonic Applications should be compatible with Airsonic. 
+
+You can find a detailed list of applications available for Subsonic on the [Subsonic App page](http://www.subsonic.org/pages/apps.jsp#silversonic).
+
+#### Applications for Your Phone
+
+| Name   | Available | Free |  Notes  |
+|:----------:|:-------:|:---------:|:-------:|:------:|
+| Subsonic  | [Google Play](https://play.google.com/store/apps/details?id=net.sourceforge.subsonic.androidapp) | ✔ |The official Subsonic app made by Sindre Mehus.
+| DSub  | [Google Play](https://play.google.com/store/apps/details?id=github.daneren2005.dsub) | ✕  | Not free but very good. Made by Scott Jackson.
+| XenoAmp  | [Google Play](https://play.google.com/store/apps/details?id=pl.qus.xenoamp&hl=en) | ✔ | Supports many different services (Soundcloud, Subsonic, SMB...)
+| Substreamer  | [Google Play](https://play.google.com/store/apps/details?id=com.ghenry22.substream2), [App Store](https://itunes.apple.com/us/app/substreamer/id1012991665?ls=1&mt=8) | ✔ | -
+| Subsonic Music Streamer | [Windows Store](https://www.microsoft.com/de-at/store/p/subsonic-music-streamer/9nblggh0dfs4?rtc=1) | ✕  | Made by Anton Van Zuylen.
+| SonicStreamer | [Windows Store](https://www.microsoft.com/de-at/store/p/sonicstreamer/9wzdncrdfk0f?rtc=1) | ✔  | 
+| BetaBeats  | [Windows Store](https://www.microsoft.com/store/apps/9nblggh6h297) | ✔  | -
+| SubSonar  | [BlackBerry World](https://appworld.blackberry.com/webstore/content/35305887/?countrycode=AT&lang=en) | ✕  | -
+| SonicAir  | [BlackBerry World](https://appworld.blackberry.com/webstore/content/55137/?lang=en&countrycode=AT) | ✕  | -
+| iSub  | [AppStore](https://itunes.apple.com/us/app/isub-music-streamer/id362920532?mt=8) | ✕  | Made by Ben Baron.
+| AVSub  | [AppStore](https://itunes.apple.com/us/app/avsub/id923424694?mt=8) | ✕  | Made by Richard Levy.
+| Soundwaves  | [AppStore](https://itunes.apple.com/app/soundwaves/id736139596?mt=8) | ✔  | Made by Simone Tellini.
+| play:Sub  | [AppStore](https://itunes.apple.com/us/app/play-sub-subsonic-music-streamer/id955329386?mt=8) | ✕  |Made by Michael Hansen.
+
+#### Other Applications 
+
+| Name   | Platform | Free |  Notes  |
+|:----------:|:-------:|:---------:|:-------:|:------:|
+| [Submariner](http://www.read-write.fr/subapp/index.php)  | Mac | ✔  | A native mac music application.
+| [Subsonic Plugin](http://musicbee.wikia.com/wiki/Subsonic_Client) for [MusicBee](https://getmusicbee.com/)  | Windows | ✔  | Provides support for many different services (SoundCloud, web radio...)
+| [Perisonic](https://chrome.google.com/webstore/detail/perisonic/bkdipjpecphmbijlckkkmabnabhbpjbn) | Google Chrome | ✔  | Plays your music in random order.
+| [PolySonic](https://chrome.google.com/webstore/detail/polysonic/dmijgonnbeadbncajpphnlidgjkgmblf) | Google Chrome | ✔  | Simple subsonic player based on Polymer.
+


### PR DESCRIPTION
As discussed, this provides an overview over apps available for Airsonic, see #9

I checked the apps available on the Subsonic App page, quite a lot of the links there are dead or lead to projects no longer maintained. The apps listed here are what's left. 