### PR TITLE
Update homebrew.md

### DIFF
--- a/install/homebrew.md
+++ b/install/homebrew.md
@@ -46,7 +46,7 @@ brew upgrade airsonic
 brew services start airsonic
 ```
 
-##### Running Airsonic with launchd
+##### Running Airsonic with launchd so that when you login Airsonic is launched
 
 ```
 cp `(brew --prefix)`/Cellar/airsonic/VERSION/homebrew.mxcl.airsonic.plist ~/Library/LaunchAgents/
@@ -54,6 +54,16 @@ launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.airsonic.plist
 ```
 
 > Replace VERSION with your Airsonic version
+```
+
+##### Running Airsonic with launchd at system boot needing no user login (background/headless)
+
+```
+cp `(brew --prefix)`/Cellar/airsonic/VERSION/homebrew.mxcl.airsonic.plist /Library/LaunchDaemons/
+```
+
+> Replace VERSION with your Airsonic version (and chown the .plist file to be root:wheel)
+```
 
 ##### Runtime settings used
 


### PR DESCRIPTION
Was able to get Airsonic to successfully launch at  system boot -- requiring NO user login -- by copying the .plist file to /Library/LuanchDaemons/ and chowning to be owned by root/wheel.  It works, but someone may want to add suggestions for how this can be done most securely, and also discuss how this is not a good idea for mobile/laptop devices running on batteries, etc.

Tested this by rebooting and verifying that Airsonic was working.