### PR TITLE
Improve documentation for transcoding

### DIFF
--- a/transcode.md
+++ b/transcode.md
@@ -26,6 +26,7 @@ Within the `transcode` directory symlink to ffmpeg and verify correct permission
 ```
 cd transcode/
 ln -s /usr/bin/ffmpeg
+chown -h user:user ffmpeg
 ls -alh
 ```
 ```
@@ -71,6 +72,7 @@ Within the `transcode` directory symlink to ffmpeg and verify correct permission
 ```
 cd transcode/
 ln -s /usr/bin/ffmpeg
+chown -h user:user ffmpeg
 ls -alh
 ```
 ```
@@ -98,6 +100,7 @@ Within the `transcode` directory symlink to ffmpeg and verify correct permission
 ```
 cd transcode/
 ln -s /usr/bin/ffmpeg
+chown -h user:user ffmpeg
 ls -alh
 ```
 ```
@@ -124,6 +127,7 @@ Within the `transcode` directory symlink to ffmpeg and verify correct permission
 ```
 cd transcode/
 ln -s /usr/bin/ffmpeg
+chown -h user:user ffmpeg
 ls -alh
 ```
 ```
@@ -155,7 +159,8 @@ Within the `transcode` directory symlink to ffmpeg and verify correct permission
 
 ```
 cd transcode/
-ln -s /usr/bin/ffmpeg
+ln -s "$(brew --prefix)/bin/ffmpeg"
+chown -h user:user ffmpeg
 ls -alh
 ```
 ```


### PR DESCRIPTION
There were two minor improvements:

* `brew` on mac doesn't install binaries into `/usr/bin/` and we can just ask for the location
* `chown` can change permissions for only the symlink, i though it would be nice to just include that so people setting it up can more or less copy and paste the instructions
