### PR TITLE
Updated contributing link and removed Homebrew instructions on JDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ To browse the documentation, we suggest you to use the [Airsonic website](https:
 
 ## Contributing
 
-Please see [this guide](https://github.com/airsonic/documentation/blob/master/CONTRIBUTING.md) for any contribution.
+Please see [this guide](https://github.com/airsonic/documentation/blob/master/.github/CONTRIBUTING.md) for any contribution.

--- a/install/homebrew.md
+++ b/install/homebrew.md
@@ -11,17 +11,32 @@ This installation method is designed for easy install and upgrades, and uses san
 
 In order to install and Airsonic on macOS you need Java 8 runtime and [Homebrew](https://brew.sh).
 
-Download the _JDK 8 .dmg_ package from the [JDK download page](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) ([direct download link](http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-macosx-x64.dmg)).
+Download the _JDK 8 .dmg_ package from the [JDK download page](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 
 Install the downloaded package.
 
 Add run the following lines in your terminal:
 
 ```bash
-# Use ~/.zshrc if you're using zsh.
+local version=$(java -version 2>&1 >/dev/null | grep 'java version' | awk '{print $3}')
 
-echo export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" >> ~/.bash_profile \
-source ~/.bash_profile
+if [[ ! $version =~ ^\"1.8.*\"$ ]]; then
+  local where_is_java=$(whereis java)
+  local profile
+
+  if [[ $(echo $0) =~ -zsh ]]; then
+    profile="~/.zshrc"
+  else
+    profile="~/.bash_profile"
+  fi
+
+  if [ ! -f $profile ]; then
+    echo "$profile not found! Exiting..."
+  fi
+
+  echo export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" >> $profile && \
+  source $profile
+fi
 ```
 
 All other dependencies will be installed and linked automatically.
@@ -83,9 +98,10 @@ Djava.awt.headless=true
 
 ##### Updating Runtime settings
 
-Use your favorite text editor and open _$(brew --prefix)/Cellar/airsonic/{{ site.stable_version }}/homebrew.mxcl.airsonic.plist_
+Use your favorite text editor and open `$(brew --prefix)/Cellar/airsonic/{{ site.stable_version }}/homebrew.mxcl.airsonic.plist`
 
 Edit any of the following properties:
+
 ```xml
 <string>-Xmx512m</string>  <!-- Max Memory -->
 <string>-Dlogging.file=/usr/local/var/log/airsonic.log</string>

--- a/install/homebrew.md
+++ b/install/homebrew.md
@@ -18,25 +18,11 @@ Install the downloaded package.
 Add run the following lines in your terminal:
 
 ```bash
-local version=$(java -version 2>&1 >/dev/null | grep 'java version' | awk '{print $3}')
+# check to see if you have 'java -version'. if not, run the command below
+# if you run zsh, replace .bash_profile with .zshrc
 
-if [[ ! $version =~ ^\"1.8.*\"$ ]]; then
-  local where_is_java=$(whereis java)
-  local profile
-
-  if [[ $(echo $0) =~ -zsh ]]; then
-    profile="~/.zshrc"
-  else
-    profile="~/.bash_profile"
-  fi
-
-  if [ ! -f $profile ]; then
-    echo "$profile not found! Exiting..."
-  fi
-
-  echo export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" >> $profile && \
-  source $profile
-fi
+echo export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" >> ~/.bash_profile && \
+source ~/.bash_profile
 ```
 
 All other dependencies will be installed and linked automatically.

--- a/install/homebrew.md
+++ b/install/homebrew.md
@@ -9,12 +9,19 @@ This installation method is designed for easy install and upgrades, and uses san
 
 ##### Prerequisites
 
-In order to install and Airsonic on macOS all you need is [Homebrew](https://brew.sh).
+In order to install and Airsonic on macOS you need Java 8 runtime and [Homebrew](https://brew.sh).
 
-Airsonic requires a recent Java runtime. The formula requires this cask, but it will not be installed automatically.
+Download the _JDK 8 .dmg_ package from the [JDK download page](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) ([direct download link](http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-macosx-x64.dmg)).
 
-```
-brew cask install java
+Install the downloaded package.
+
+Add run the following lines in your terminal:
+
+```bash
+# Use ~/.zshrc if you're using zsh.
+
+echo export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" >> ~/.bash_profile \
+source ~/.bash_profile
 ```
 
 All other dependencies will be installed and linked automatically.
@@ -72,4 +79,22 @@ Dserver.port=4040
 Dserver.context-path=/
 Dairsonic.home=#{workingdir}
 Djava.awt.headless=true
+```
+
+##### Updating Runtime settings
+
+Use your favorite text editor and open _$(brew --prefix)/Cellar/airsonic/{{ site.stable_version }}/homebrew.mxcl.airsonic.plist_
+
+Edit any of the following properties:
+```xml
+<string>-Xmx512m</string>  <!-- Max Memory -->
+<string>-Dlogging.file=/usr/local/var/log/airsonic.log</string>
+<string>-Dlogging.level.root=ERROR</string>
+<string>-Dserver.host=0.0.0.0</string>
+<string>-Dserver.port=4040</string>
+<string>-Dserver.context-path=/</string>  <!-- localhost:port/context-path, e.g.: /airsonic -->
+<string>-Dairsonic.home=/usr/local/var/airsonic</string>
+<string>-Djava.awt.headless=true</string>
+<string>-jar</string>
+<string>/usr/local/Cellar/airsonic/{{ site.stable_version }}/airsonic.war</string>
 ```

--- a/install/prerequisites.md
+++ b/install/prerequisites.md
@@ -165,22 +165,23 @@ Click OK and Apply Changes as prompted
 
 ##### On MacOS
 
-Download the JDK 8 .dmg package from the [JDK download page](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
+Download the _JDK 8 .dmg_ package from the [JDK download page](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) ([direct download link](http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-macosx-x64.dmg)).
 
 Install the downloaded package.
 
-Add the following lines to your ` ~/.bash_profile` file:
+Add run the following lines in your terminal:
+
+```bash
+# Use ~/.zshrc if you're using zsh.
+
+echo export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" >> ~/.bash_profile \
+source ~/.bash_profile
+```
+
+All other dependencies will be installed and linked automatically.
+
+To easily load Airsonic, and start it with your system services, you should also install the [Homebrew Services](https://github.com/Homebrew/homebrew-services) tap.
 
 ```
-export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
-```
-
-##### On MacOS (Homebrew)
-
-First install [Homebrew](https://brew.sh) if you haven't already.
-
-Then, to install the latest version of Java:
-
-```
-brew cask install java
+brew tap homebrew/services
 ```

--- a/install/prerequisites.md
+++ b/install/prerequisites.md
@@ -172,10 +172,25 @@ Install the downloaded package.
 Add run the following lines in your terminal:
 
 ```bash
-# Use ~/.zshrc if you're using zsh.
+local version=$(java -version 2>&1 >/dev/null | grep 'java version' | awk '{print $3}')
 
-echo export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" >> ~/.bash_profile \
-source ~/.bash_profile
+if [[ ! $version =~ ^\"1.8.*\"$ ]]; then
+  local where_is_java=$(whereis java)
+  local profile
+
+  if [[ $(echo $0) =~ -zsh ]]; then
+    profile="~/.zshrc"
+  else
+    profile="~/.bash_profile"
+  fi
+
+  if [ ! -f $profile ]; then
+    echo "$profile not found! Exiting..."
+  fi
+
+  echo export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" >> $profile && \
+  source $profile
+fi
 ```
 
 All other dependencies will be installed and linked automatically.

--- a/install/prerequisites.md
+++ b/install/prerequisites.md
@@ -172,25 +172,12 @@ Install the downloaded package.
 Add run the following lines in your terminal:
 
 ```bash
-local version=$(java -version 2>&1 >/dev/null | grep 'java version' | awk '{print $3}')
+# check to see if you have 'java -version'. if not, run the command below
+# if you run zsh, replace .bash_profile with .zshrc
 
-if [[ ! $version =~ ^\"1.8.*\"$ ]]; then
-  local where_is_java=$(whereis java)
-  local profile
-
-  if [[ $(echo $0) =~ -zsh ]]; then
-    profile="~/.zshrc"
-  else
-    profile="~/.bash_profile"
-  fi
-
-  if [ ! -f $profile ]; then
-    echo "$profile not found! Exiting..."
-  fi
-
-  echo export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" >> $profile && \
-  source $profile
-fi
+echo export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" >> ~/.bash_profile && \
+source ~/.bash_profile
+```
 ```
 
 All other dependencies will be installed and linked automatically.


### PR DESCRIPTION
The Homebrew cask install of JDK is OpenJDK 11. Airsonic does not work with JDK 11. So I updated the instructions to use Oracle JDK 8, which is on the Prerequisites page.

Also updated this on the main page. I don't know if you want to merge this to master as well.