### PR TITLE
Update Caddy proxy instructions to Caddy v2

### DIFF
--- a/proxy/caddy.md
+++ b/proxy/caddy.md
@@ -8,7 +8,30 @@ The following configuration works for HTTPS (with an HTTP redirection).
 
 > **NOTE**: Make sure you follow the [prerequisites](/docs/proxy/prerequisites/).
 
-#### Caddy configuration
+#### Caddy v2 configuration
+
+Edit the main Caddyfile (assuming `/etc/caddy/Caddyfile` is the main Caddyfile):
+
+```
+sudo nano /etc/caddy/Caddyfile
+```
+
+Paste the following configuration in the Caddyfile:
+
+```caddy
+airsonic.mydomain.com {
+    reverse_proxy 127.0.0.1:8080
+}
+```
+
+Check the Caddy config for validity, and then restart the Caddy service:
+
+```
+caddy validate --config /etc/caddy/Caddyfile 
+sudo systemctl restart caddy.service
+```
+
+#### Caddy v1 configuration
 
 Create a new virtual host file (assumes `/etc/caddy/caddy.conf` is your main file, and includes all `*.conf` files in `/etc/caddy/caddy.conf.d/` directory):
 


### PR DESCRIPTION
Caddy v2 has a dedicated `reverse_proxy` command for the reverse proxy functionality.
Also the validate command line format has changed between versions.
Add another section to the documentation for Caddy v2 and mark the
previous documentation as 'v1' explicitly.

Signed-off-by: hayalci <gokdenizk@gmail.com>